### PR TITLE
Fix - config_files on Windows is broken

### DIFF
--- a/lua/exer/core/io.lua
+++ b/lua/exer/core/io.lua
@@ -73,7 +73,11 @@ end
 ---@return string Project root path
 function M.getRoot()
   local cwd = vim.fn.getcwd()
-  local gitRoot = vim.fn.systemlist('git rev-parse --show-toplevel 2>/dev/null')[1]
+  local git_cmd = 'git rev-parse --show-toplevel '
+  if vim.loop.os_uname().sysname:find("Windows") == 0 then
+    git_cmd = git_cmd .. '2>/dev/null'
+  end
+  local gitRoot = vim.fn.systemlist(git_cmd)[1]
 
   if gitRoot and gitRoot ~= '' then return gitRoot end
 


### PR DESCRIPTION
If you use config_files on Windows, the redirect to /dev/null results in a git path that is the literal string
'The system cannot find the path specified'.  No config files are loaded.

## Description

<!-- Describe your changes -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] I have tested my changes
- [ ] All tests pass
- [ ] I have added tests for new functionality

## Related Issue

<!-- Link to related issue if applicable -->